### PR TITLE
Fix outbox email delivery and reservation reaper

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "outbox:drain": "tsx src/workers/outboxDrain.ts",
+    "reservation:reap": "tsx src/workers/reservationReaper.ts",
     "vercel-build": "tsc",
     "type-check": "tsc --noEmit"
   },

--- a/src/controllers/OrderController.ts
+++ b/src/controllers/OrderController.ts
@@ -1,7 +1,6 @@
 import type { Request, Response } from "express";
 import { asyncHandler } from "../middleware/asyncHandler.js";
 import { OrderService } from "../services/OrderService.js";
-import { OutboxProcessor } from "../services/OutboxProcessor.js";
 import { ValidationError } from "../utils/AppError.js";
 import { parsePaystackWebhook } from "../payments/webhook.js";
 import type { z } from "zod";
@@ -149,10 +148,6 @@ export class OrderController {
         default:
           throw ValidationError(`Invalid target status: ${status}`);
       }
-
-      OutboxProcessor.drainOnce().catch((err) =>
-        console.error("Instant outbox drain failed:", err)
-      );
 
       res.status(200).json({
         success: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { corsOptions, devCorsOptions } from "./config/cors.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { ogBotMiddleware } from "./middleware/ogBotMiddleware.js";
 import { OrderController } from "./controllers/OrderController.js";
+import { ReservationReaperService } from "./services/ReservationReaperService.js";
 
 import {
   userRoutes,
@@ -57,16 +58,15 @@ app.use(
   cors(process.env.NODE_ENV === "production" ? corsOptions : devCorsOptions)
 );
 
-if (process.env.NODE_ENV === "production") {
-  app.use(async (_req: Request, _res: Response, next: NextFunction) => {
-    try {
-      await connectToDatabase();
-      next();
-    } catch (error) {
-      next(error);
-    }
-  });
-}
+app.use(async (_req: Request, _res: Response, next: NextFunction) => {
+  try {
+    await connectToDatabase();
+    ReservationReaperService.kickFromRequest();
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
 
 app.post(
   "/api/orders/webhook/paystack",
@@ -128,6 +128,17 @@ app.use(errorHandler);
 if (process.env.NODE_ENV !== "production") {
   connectToDatabase()
     .then(() => {
+      if (process.env.DISABLE_RESERVATION_REAPER !== "true") {
+        const raw = Number(process.env.RESERVATION_REAPER_INTERVAL_MS);
+        const intervalMs =
+          Number.isFinite(raw) && raw > 0 ? raw : 60_000;
+        setInterval(() => {
+          void ReservationReaperService.runOnce({ quiet: true }).catch(
+            (err) => console.error("[reaper] interval run failed:", err)
+          );
+        }, intervalMs);
+      }
+
       app.listen(PORT, () => {
         console.log(` Server running on port ${PORT}`);
         console.log(` Environment: ${process.env.NODE_ENV || "development"}`);

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -16,6 +16,7 @@ import {
 import { NotFoundError, ValidationError, FsmError } from "../utils/AppError.js";
 import { InventoryService } from "./InventoryService.js";
 import { resolveGateway, type ChargeParams } from "../payments/index.js";
+import { OutboxProcessor } from "./OutboxProcessor.js";
 import { OutboxService } from "./OutboxService.js";
 import {
   ORDER_GUEST_MAX_ITEMS_TOTAL_KOBO,
@@ -449,25 +450,27 @@ export class OrderService {
       await order.save({ session });
       await session.commitTransaction();
 
-      // Enqueue relevant emails (fire-and-forget, outside the txn)
       if (nextStatus === "DELIVERED") {
         await OutboxService.enqueue({
           type: "ORDER_DELIVERED",
           dedupeKey: `order:${orderId}:delivered`,
           payload: { orderId },
         });
+        OutboxProcessor.scheduleDrain();
       } else if (nextStatus === "CONFIRMED") {
         await OutboxService.enqueue({
           type: "ORDER_CONFIRMED",
           dedupeKey: `order:${orderId}:confirmed`,
           payload: { orderId },
         });
+        OutboxProcessor.scheduleDrain();
       } else if (nextStatus === "SHIPPED") {
         await OutboxService.enqueue({
           type: "ORDER_SHIPPED",
           dedupeKey: `order:${orderId}:shipped`,
           payload: { orderId, note },
         });
+        OutboxProcessor.scheduleDrain();
       }
 
       return order.toObject() as IOrder;
@@ -546,6 +549,7 @@ export class OrderService {
 
       await order.save({ session });
       await session.commitTransaction();
+      OutboxProcessor.scheduleDrain();
       return order.toObject() as IOrder;
     } catch (error) {
       await session.abortTransaction();
@@ -806,6 +810,10 @@ export class OrderService {
 
       await order.save({ session });
       await session.commitTransaction();
+
+      if (result.success) {
+        OutboxProcessor.scheduleDrain();
+      }
 
       return {
         order: order.toObject() as IOrder,

--- a/src/services/OutboxProcessor.ts
+++ b/src/services/OutboxProcessor.ts
@@ -14,6 +14,13 @@ function backoffMs(attempts: number): number {
 }
 
 export class OutboxProcessor {
+ 
+  static scheduleDrain(): void {
+    void this.drainOnce().catch((err) =>
+      console.error("Instant outbox drain failed:", err)
+    );
+  }
+
   static async drainOnce(opts: ProcessOptions = {}): Promise<{
     processed: number;
     succeeded: number;

--- a/src/services/ReservationReaperService.ts
+++ b/src/services/ReservationReaperService.ts
@@ -1,0 +1,109 @@
+import mongoose from "mongoose";
+import { Order, type OrderStatus } from "../models/index.js";
+import { InventoryService } from "./InventoryService.js";
+
+function reservationTtlMs(): number {
+  const n = Number(process.env.RESERVATION_TTL_MS);
+  return Number.isFinite(n) && n > 0 ? n : 15 * 60_000;
+}
+
+export type RunReservationReaperOptions = {
+  
+  quiet?: boolean;
+};
+
+
+export class ReservationReaperService {
+  private static lastRequestKickoff = 0;
+
+  
+  static kickFromRequest(): void {
+    if (process.env.DISABLE_RESERVATION_REAPER === "true") return;
+
+    const raw = Number(process.env.RESERVATION_REAPER_THROTTLE_MS);
+    const throttleMs =
+      Number.isFinite(raw) && raw > 0 ? raw : 60_000;
+
+    const now = Date.now();
+    if (now - this.lastRequestKickoff < throttleMs) return;
+    this.lastRequestKickoff = now;
+
+    void this.runOnce({ quiet: true }).catch((err) =>
+      console.error("[reaper] background run failed:", err)
+    );
+  }
+
+  static async runOnce(
+    opts: RunReservationReaperOptions = {}
+  ): Promise<{ scanned: number; released: number; failed: number }> {
+    const ttlMs = reservationTtlMs();
+    const cutoff = new Date(Date.now() - ttlMs);
+
+    const staleOrders = await Order.find({
+      status: "PENDING",
+      createdAt: { $lte: cutoff },
+    }).lean();
+
+    if (staleOrders.length === 0) {
+      if (!opts.quiet) {
+        console.log("[reaper] no stale reservations found");
+      }
+      return { scanned: 0, released: 0, failed: 0 };
+    }
+
+    if (!opts.quiet) {
+      console.log(
+        `[reaper] found ${staleOrders.length} stale PENDING order(s)`
+      );
+    }
+
+    let released = 0;
+    let failed = 0;
+
+    for (const order of staleOrders) {
+      const session = await mongoose.startSession();
+      session.startTransaction();
+
+      try {
+        const liveOrder = await Order.findById(order._id).session(session);
+        if (!liveOrder || liveOrder.status !== "PENDING") {
+          await session.abortTransaction();
+          continue;
+        }
+
+        for (const item of liveOrder.items) {
+          await InventoryService.releaseReservation(
+            item.product.toString(),
+            item.quantity,
+            session
+          );
+        }
+
+        liveOrder.status = "FAILED" as OrderStatus;
+        liveOrder.statusHistory.push({
+          status: "FAILED" as OrderStatus,
+          timestamp: new Date(),
+          note: "Reservation expired — auto-released by reaper",
+        });
+
+        await liveOrder.save({ session });
+        await session.commitTransaction();
+        released++;
+      } catch (err) {
+        await session.abortTransaction();
+        console.error(`[reaper] failed to release order ${order._id}:`, err);
+        failed++;
+      } finally {
+        session.endSession();
+      }
+    }
+
+    if (!opts.quiet) {
+      console.log(
+        `[reaper] done: released=${released} failed=${failed} total=${staleOrders.length}`
+      );
+    }
+
+    return { scanned: staleOrders.length, released, failed };
+  }
+}

--- a/src/workers/reservationReaper.ts
+++ b/src/workers/reservationReaper.ts
@@ -1,73 +1,10 @@
 import "dotenv/config";
-import mongoose from "mongoose";
 import { connectToDatabase } from "../index.js";
-import { Order, type OrderStatus } from "../models/index.js";
-import { InventoryService } from "../services/InventoryService.js";
-
-const RESERVATION_TTL_MS =
-  Number(process.env.RESERVATION_TTL_MS) || 15 * 60_000;
+import { ReservationReaperService } from "../services/ReservationReaperService.js";
 
 async function main() {
   await connectToDatabase();
-
-  const cutoff = new Date(Date.now() - RESERVATION_TTL_MS);
-
-  const staleOrders = await Order.find({
-    status: "PENDING",
-    createdAt: { $lte: cutoff },
-  }).lean();
-
-  if (staleOrders.length === 0) {
-    console.log("[reaper] no stale reservations found");
-    return;
-  }
-
-  console.log(`[reaper] found ${staleOrders.length} stale PENDING order(s)`);
-
-  let released = 0;
-  let failed = 0;
-
-  for (const order of staleOrders) {
-    const session = await mongoose.startSession();
-    session.startTransaction();
-
-    try {
-      const liveOrder = await Order.findById(order._id).session(session);
-      if (!liveOrder || liveOrder.status !== "PENDING") {
-        await session.abortTransaction();
-        continue;
-      }
-
-      for (const item of liveOrder.items) {
-        await InventoryService.releaseReservation(
-          item.product.toString(),
-          item.quantity,
-          session
-        );
-      }
-
-      liveOrder.status = "FAILED" as OrderStatus;
-      liveOrder.statusHistory.push({
-        status: "FAILED" as OrderStatus,
-        timestamp: new Date(),
-        note: "Reservation expired — auto-released by reaper",
-      });
-
-      await liveOrder.save({ session });
-      await session.commitTransaction();
-      released++;
-    } catch (err) {
-      await session.abortTransaction();
-      console.error(`[reaper] failed to release order ${order._id}:`, err);
-      failed++;
-    } finally {
-      session.endSession();
-    }
-  }
-
-  console.log(
-    `[reaper] done: released=${released} failed=${failed} total=${staleOrders.length}`
-  );
+  await ReservationReaperService.runOnce({ quiet: false });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Closes #6

## Summary
- **Outbox:** Schedule processing after enqueue from all order/payment paths so confirmation, ship, deliver, cancel, and Paystack verification send email promptly.
- **Reservations:** Run the stale-\PENDING\ reaper via a shared service, npm script \eservation:reap\, throttled post-connect kicks, and a dev interval.

## Commits (one file each)
1. \src/services/OutboxProcessor.ts\ — \scheduleDrain()\
2. \src/services/OrderService.ts\ — drain after enqueue / verify
3. \src/controllers/OrderController.ts\ — remove redundant controller drain
4. \src/services/ReservationReaperService.ts\ — new service
5. \src/workers/reservationReaper.ts\ — delegate to service
6. \src/index.ts\ — middleware + dev interval
7. \package.json\ — \eservation:reap\ script

Made with [Cursor](https://cursor.com)