### PR TITLE
Wallet ledger + payment verify events

### DIFF
--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -1,0 +1,55 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../middleware/asyncHandler.js";
+import { LedgerEntry, Wallet, type ILedgerEntry } from "../models/index.js";
+import { NotFoundError, ValidationError } from "../utils/AppError.js";
+import type { z } from "zod";
+import type {
+  walletLedgerParamsSchema,
+  walletLedgerQuerySchema,
+} from "../schemas/walletSchemas.js";
+
+export class WalletController {
+  static getLedger = asyncHandler(async (req: Request, res: Response) => {
+    const { walletId } = req.params as z.infer<typeof walletLedgerParamsSchema>;
+    const { page, limit, from, to } = req.query as unknown as z.infer<
+      typeof walletLedgerQuerySchema
+    >;
+
+    if (from && to && from > to) {
+      throw ValidationError("`from` date cannot be after `to` date.");
+    }
+
+    const wallet = await Wallet.findById(walletId).lean();
+    if (!wallet) throw NotFoundError("Wallet");
+
+    const skip = (page - 1) * limit;
+    const filter: Record<string, unknown> = { walletId: wallet._id };
+    if (from || to) {
+      filter.createdAt = {};
+      if (from) (filter.createdAt as Record<string, unknown>).$gte = from;
+      if (to) (filter.createdAt as Record<string, unknown>).$lte = to;
+    }
+
+    const [entries, total] = await Promise.all([
+      LedgerEntry.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean<ILedgerEntry[]>(),
+      LedgerEntry.countDocuments(filter),
+    ]);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        wallet,
+        entries,
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  });
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   orderRoutes,
   seoRoutes,
   storageRoutes,
+  walletRoutes,
 } from "./routes/index.js";
 
 const app = express();
@@ -97,6 +98,7 @@ app.get("/", (_req: Request, res: Response) => {
       inventory: "/api/inventory",
       cart: "/api/cart",
       orders: "/api/orders",
+      wallets: "/api/wallets",
       storage: "/api/storage",
     },
   });
@@ -117,6 +119,7 @@ app.use("/api/products", productRoutes);
 app.use("/api/inventory", inventoryRoutes);
 app.use("/api/cart", cartRoutes);
 app.use("/api/orders", orderRoutes);
+app.use("/api/wallets", walletRoutes);
 app.use("/api/storage", storageRoutes);
 
 app.use("/", seoRoutes);

--- a/src/models/LedgerEntry.ts
+++ b/src/models/LedgerEntry.ts
@@ -17,8 +17,7 @@ export interface IActorRef {
   id?: Types.ObjectId;
 }
 
-export interface ILedgerEntry extends Document {
-  _id: Types.ObjectId;
+export interface ILedgerEntryAttrs {
   transactionId: Types.ObjectId;
   walletId: Types.ObjectId;
   currency: string;
@@ -33,6 +32,10 @@ export interface ILedgerEntry extends Document {
   dedupeKey?: string;
   balanceAfterAvailable?: number;
   balanceAfterPending?: number;
+}
+
+export interface ILedgerEntry extends Document, ILedgerEntryAttrs {
+  _id: Types.ObjectId;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -54,6 +54,7 @@ export {
 export {
   LedgerEntry,
   type ILedgerEntry,
+  type ILedgerEntryAttrs,
   type LedgerBucket,
   type LedgerDirection,
   type LedgerEntryType,

--- a/src/payments/paystack-adapter.ts
+++ b/src/payments/paystack-adapter.ts
@@ -46,6 +46,8 @@ export class PaystackGateway implements PaymentGateway {
       return {
         success: true,
         providerRef: data.reference,
+        amountPaid: data.amount,
+        gatewayFee: data.fees,
         paidAt: data.paid_at,
         metadata: {
           channel: data.channel,
@@ -59,6 +61,8 @@ export class PaystackGateway implements PaymentGateway {
     return {
       success: false,
       providerRef: data.reference,
+      amountPaid: data.amount,
+      gatewayFee: data.fees,
       failureReason: data.gateway_response || `Payment ${data.status}`,
       metadata: {
         channel: data.channel,

--- a/src/payments/paystack-client.ts
+++ b/src/payments/paystack-client.ts
@@ -44,6 +44,7 @@ type PaystackVerifyResponse = {
     status: "success" | "failed" | "abandoned";
     reference: string;
     amount: number;
+    fees?: number;
     currency: string;
     gateway_response: string;
     paid_at: string | null;

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -19,6 +19,8 @@ export type InitializeResult = {
 export type VerifyResult = {
   success: boolean;
   providerRef: string;
+  amountPaid?: number;
+  gatewayFee?: number;
   failureReason?: string;
   paidAt?: string | null;
   metadata?: Record<string, unknown>;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,3 @@
-/**
- * Barrel export for all routes.
- * Import from here: import { userRoutes } from "./routes/index.js";
- */
 
 export { default as userRoutes } from "./userRoutes.js";
 export { default as productRoutes } from "./productRoutes.js";
@@ -10,3 +6,4 @@ export { default as cartRoutes } from "./cartRoutes.js";
 export { default as orderRoutes } from "./orderRoutes.js";
 export { default as seoRoutes } from "./seoRoutes.js";
 export { default as storageRoutes } from "./storageRoutes.js";
+export { default as walletRoutes } from "./walletRoutes.js";

--- a/src/routes/walletRoutes.ts
+++ b/src/routes/walletRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { WalletController } from "../controllers/WalletController.js";
+import { authMiddleware } from "../middleware/authMiddleware.js";
+import { requireRole } from "../middleware/requireRole.js";
+import { validate } from "../middleware/validate.js";
+import {
+  walletLedgerParamsSchema,
+  walletLedgerQuerySchema,
+} from "../schemas/walletSchemas.js";
+
+const router = Router();
+
+router.get(
+  "/:walletId/ledger",
+  authMiddleware,
+  requireRole("ADMIN"),
+  validate(walletLedgerParamsSchema, "params"),
+  validate(walletLedgerQuerySchema, "query"),
+  WalletController.getLedger
+);
+
+export default router;
+

--- a/src/schemas/walletSchemas.ts
+++ b/src/schemas/walletSchemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const objectIdSchema = z
+  .string()
+  .regex(/^[0-9a-fA-F]{24}$/, "Invalid id format");
+
+export const walletLedgerParamsSchema = z.object({
+  walletId: objectIdSchema,
+});
+
+export const walletLedgerQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+});
+

--- a/src/services/LedgerService.ts
+++ b/src/services/LedgerService.ts
@@ -1,0 +1,180 @@
+import mongoose from "mongoose";
+import {
+  LedgerEntry,
+  Wallet,
+  type IWallet,
+  type ILedgerEntryAttrs,
+  type LedgerBucket,
+  type LedgerDirection,
+  type LedgerEntryType,
+  type ILedgerActorRef,
+  Transaction,
+} from "../models/index.js";
+import { ValidationError } from "../utils/AppError.js";
+
+const STORE_OWNER_ID = new mongoose.Types.ObjectId("000000000000000000000001");
+
+type LedgerLine = {
+  walletId: mongoose.Types.ObjectId;
+  currency: string;
+  bucket: LedgerBucket;
+  direction: LedgerDirection;
+  amount: number;
+  entryType: LedgerEntryType;
+  narration?: string;
+  dedupeKey?: string;
+};
+
+function deltaFor(
+  direction: LedgerDirection,
+  amount: number
+): number {
+  return direction === "CREDIT" ? amount : -amount;
+}
+
+async function getOrCreateStoreWallet(params: {
+  session: mongoose.ClientSession;
+  currency: string;
+}): Promise<IWallet> {
+  const { session, currency } = params;
+  const existing = await Wallet.findOne({
+    ownerType: "STORE",
+    ownerId: STORE_OWNER_ID,
+    currency,
+  }).session(session);
+  if (existing) return existing;
+
+  const [created] = await Wallet.create(
+    [
+      {
+        ownerType: "STORE" as const,
+        ownerId: STORE_OWNER_ID,
+        currency,
+        available: 0,
+        pending: 0,
+        status: "ACTIVE" as const,
+      },
+    ],
+    { session }
+  );
+  if (!created) throw new Error("Failed to create store wallet");
+  return created;
+}
+
+export class LedgerService {
+  /**
+   * Posts an order payment journal to the STORE wallet:
+   * - CREDIT PAYMENT for amountPaid
+   * - DEBIT FEE for gatewayFee (if any)
+   */
+  static async postStoreOrderPayment(params: {
+    session: mongoose.ClientSession;
+    transactionId: string;
+    currency: string;
+    amountPaid: number;
+    gatewayFee?: number;
+    actor: ILedgerActorRef;
+    source: string;
+    traceId: string;
+  }): Promise<void> {
+    const {
+      session,
+      transactionId,
+      currency,
+      amountPaid,
+      gatewayFee = 0,
+      actor,
+      source,
+      traceId,
+    } = params;
+
+    if (!Number.isInteger(amountPaid) || amountPaid < 1) {
+      throw ValidationError("amountPaid must be a positive integer (kobo).");
+    }
+    if (!Number.isInteger(gatewayFee) || gatewayFee < 0) {
+      throw ValidationError("gatewayFee must be a non-negative integer (kobo).");
+    }
+    if (gatewayFee > amountPaid) {
+      throw ValidationError("gatewayFee cannot exceed amountPaid.");
+    }
+
+    const tx = await Transaction.findById(transactionId).session(session);
+    if (!tx) throw ValidationError("Transaction not found for ledger posting.");
+    if (tx.postedAt) return; 
+
+    const storeWallet = await getOrCreateStoreWallet({ session, currency });
+
+    const lines: LedgerLine[] = [
+      {
+        walletId: storeWallet._id,
+        currency,
+        bucket: "AVAILABLE",
+        direction: "CREDIT",
+        amount: amountPaid,
+        entryType: "PAYMENT",
+        narration: "Order payment received",
+        dedupeKey: `tx:${transactionId}:payment`,
+      },
+    ];
+    if (gatewayFee > 0) {
+      lines.push({
+        walletId: storeWallet._id,
+        currency,
+        bucket: "AVAILABLE",
+        direction: "DEBIT",
+        amount: gatewayFee,
+        entryType: "FEE",
+        narration: "Payment gateway fee",
+        dedupeKey: `tx:${transactionId}:fee`,
+      });
+    }
+
+    for (const line of lines) {
+      const wallet = await Wallet.findById(line.walletId).session(session);
+      if (!wallet) throw ValidationError("Wallet not found.");
+      if (wallet.status === "FROZEN") {
+        throw ValidationError("Wallet is frozen.");
+      }
+      if (wallet.currency !== line.currency) {
+        throw ValidationError("Wallet currency mismatch.");
+      }
+
+      const delta = deltaFor(line.direction, line.amount);
+      if (line.bucket === "AVAILABLE") {
+        const next = wallet.available + delta;
+        if (next < 0) throw ValidationError("Insufficient available balance.");
+        wallet.available = next;
+      } else {
+        const next = wallet.pending + delta;
+        if (next < 0) throw ValidationError("Insufficient pending balance.");
+        wallet.pending = next;
+      }
+
+      await wallet.save({ session });
+
+      const entry: ILedgerEntryAttrs = {
+        transactionId: new mongoose.Types.ObjectId(transactionId),
+        walletId: wallet._id,
+        currency: line.currency,
+        bucket: line.bucket,
+        direction: line.direction,
+        amount: line.amount,
+        entryType: line.entryType,
+        narration: line.narration,
+        actor,
+        source,
+        traceId,
+        dedupeKey: line.dedupeKey,
+        balanceAfterAvailable: wallet.available,
+        balanceAfterPending: wallet.pending,
+      };
+
+      await LedgerEntry.create([entry], { session });
+    }
+
+    tx.postedAt = new Date();
+    tx.gatewayFee = gatewayFee;
+    await tx.save({ session });
+  }
+}
+

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -8,6 +8,7 @@ import {
   Product,
   Transaction,
   type ITransaction,
+  type TransactionStatus,
   type PaymentMethod,
   User,
   TrackingEvent,
@@ -18,6 +19,8 @@ import { InventoryService } from "./InventoryService.js";
 import { resolveGateway, type ChargeParams } from "../payments/index.js";
 import { OutboxProcessor } from "./OutboxProcessor.js";
 import { OutboxService } from "./OutboxService.js";
+import { LedgerService } from "./LedgerService.js";
+import { TransactionEventService } from "./TransactionEventService.js";
 import {
   ORDER_GUEST_MAX_ITEMS_TOTAL_KOBO,
   ORDER_GUEST_MAX_ITEMS_TOTAL_NGN,
@@ -69,6 +72,28 @@ const ALLOWED_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
 
 function assertValidTransition(current: OrderStatus, next: OrderStatus): void {
   const allowed = ALLOWED_TRANSITIONS[current];
+  if (!allowed.includes(next)) {
+    throw FsmError(current, next, allowed);
+  }
+}
+
+/* Transaction FSM */
+
+const ALLOWED_TX_TRANSITIONS: Record<TransactionStatus, TransactionStatus[]> = {
+  INITIATED: ["PROCESSING", "FAILED"],
+  PROCESSING: ["VERIFYING", "FAILED"],
+  VERIFYING: ["SUCCESS", "FAILED", "PROCESSING"],
+  SUCCESS: ["REFUND_INITIATED"],
+  FAILED: [],
+  REFUND_INITIATED: ["REFUNDED", "FAILED"],
+  REFUNDED: [],
+};
+
+function assertValidTxTransition(
+  current: TransactionStatus,
+  next: TransactionStatus
+): void {
+  const allowed = ALLOWED_TX_TRANSITIONS[current];
   if (!allowed.includes(next)) {
     throw FsmError(current, next, allowed);
   }
@@ -756,14 +781,45 @@ export class OrderService {
     session.startTransaction();
 
     try {
-      const order = await Order.findById(claimed.order).session(session);
+      /* Re-fetch claimed inside the session for snapshot isolation */
+      const freshClaimed = await Transaction.findById(claimed._id).session(
+        session
+      );
+      if (!freshClaimed) throw NotFoundError("Transaction");
+
+      const order = await Order.findById(freshClaimed.order).session(session);
       if (!order) throw NotFoundError("Order");
 
       if (result.success) {
-        claimed.status = "SUCCESS";
-        claimed.paidAt = result.paidAt ? new Date(result.paidAt) : new Date();
-        if (result.metadata) claimed.metadata = result.metadata;
-        await claimed.save({ session });
+        assertValidTransition(order.status, "CONFIRMED");
+        assertValidTxTransition(freshClaimed.status, "SUCCESS");
+
+        const amountPaid =
+          typeof result.amountPaid === "number"
+            ? result.amountPaid
+            : freshClaimed.amount;
+        const gatewayFee =
+          typeof result.gatewayFee === "number" ? result.gatewayFee : 0;
+
+        freshClaimed.status = "SUCCESS";
+        freshClaimed.paidAt = result.paidAt
+          ? new Date(result.paidAt)
+          : new Date();
+        freshClaimed.gatewayFee = gatewayFee;
+        if (result.metadata) freshClaimed.metadata = result.metadata;
+        await freshClaimed.save({ session });
+
+        await TransactionEventService.record({
+          session,
+          transactionId: freshClaimed._id.toString(),
+          previousStatus: "VERIFYING",
+          newStatus: "SUCCESS",
+          reason: "payment_confirmed",
+          actor: { type: "SYSTEM" },
+          source: "payment:verify",
+          traceId: `pay:${reference}`,
+          metadata: { providerRef: result.providerRef },
+        });
 
         for (const item of order.items) {
           await InventoryService.commitReservation(
@@ -779,6 +835,26 @@ export class OrderService {
           timestamp: new Date(),
           note: "Payment verified successfully",
         });
+
+        order.payment = {
+          provider: freshClaimed.provider,
+          reference: result.providerRef,
+          amountPaid,
+          gatewayFee,
+          paidAt: freshClaimed.paidAt,
+        };
+
+        await LedgerService.postStoreOrderPayment({
+          session,
+          transactionId: freshClaimed._id.toString(),
+          currency: freshClaimed.currency,
+          amountPaid,
+          gatewayFee,
+          actor: { type: "SYSTEM" },
+          source: "paystack:verify",
+          traceId: `pay:${reference}`,
+        });
+
         await TrackingEvent.create(
           [
             {
@@ -796,18 +872,36 @@ export class OrderService {
             dedupeKey: `order:${order._id.toString()}:confirmed`,
             payload: {
               orderId: order._id.toString(),
-              transactionId: claimed._id.toString(),
+              transactionId: freshClaimed._id.toString(),
               paymentReference: reference,
             },
           },
           session
         );
       } else {
-        claimed.status = "FAILED";
-        claimed.failureReason =
+        assertValidTransition(order.status, "FAILED");
+        assertValidTxTransition(freshClaimed.status, "FAILED");
+
+        freshClaimed.status = "FAILED";
+        freshClaimed.failureReason =
           result.failureReason ?? "Payment declined by provider.";
-        if (result.metadata) claimed.metadata = result.metadata;
-        await claimed.save({ session });
+        if (result.metadata) freshClaimed.metadata = result.metadata;
+        await freshClaimed.save({ session });
+
+        await TransactionEventService.record({
+          session,
+          transactionId: freshClaimed._id.toString(),
+          previousStatus: "VERIFYING",
+          newStatus: "FAILED",
+          reason: "payment_failed",
+          actor: { type: "SYSTEM" },
+          source: "payment:verify",
+          traceId: `pay:${reference}`,
+          metadata: {
+            providerRef: result.providerRef,
+            failureReason: freshClaimed.failureReason,
+          },
+        });
 
         for (const item of order.items) {
           await InventoryService.releaseReservation(
@@ -818,7 +912,7 @@ export class OrderService {
         }
 
         order.status = "FAILED";
-        const failureNote = claimed.failureReason || "Payment failed";
+        const failureNote = freshClaimed.failureReason || "Payment failed";
         order.statusHistory.push({
           status: "FAILED",
           timestamp: new Date(),
@@ -839,7 +933,7 @@ export class OrderService {
 
       return {
         order: order.toObject() as IOrder,
-        transaction: claimed.toObject() as ITransaction,
+        transaction: freshClaimed.toObject() as ITransaction,
       };
     } catch (error) {
       await session.abortTransaction();
@@ -893,8 +987,7 @@ export class OrderService {
       eventData
     )) as unknown as ITrackingEvent;
 
-    // Optionally update the high-level order status if it differs
-    // and make sure it's a valid transition to prevent breaking the state machine.
+
     if (order.status !== status) {
       assertValidTransition(order.status, status);
       order.status = status;

--- a/src/services/TransactionEventService.ts
+++ b/src/services/TransactionEventService.ts
@@ -1,0 +1,49 @@
+import type mongoose from "mongoose";
+import {
+  TransactionEvent,
+  type TransactionStatus,
+  type ITransactionActorRef,
+} from "../models/index.js";
+
+export class TransactionEventService {
+  static async record(params: {
+    session: mongoose.ClientSession;
+    transactionId: string;
+    previousStatus: TransactionStatus;
+    newStatus: TransactionStatus;
+    reason: string;
+    actor: ITransactionActorRef;
+    source: string;
+    traceId: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    const {
+      session,
+      transactionId,
+      previousStatus,
+      newStatus,
+      reason,
+      actor,
+      source,
+      traceId,
+      metadata,
+    } = params;
+
+    await TransactionEvent.create(
+      [
+        {
+          transactionId,
+          previousStatus,
+          newStatus,
+          reason,
+          actor,
+          source,
+          traceId,
+          metadata,
+        },
+      ],
+      { session }
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add wallet ledger endpoint (controller, routes, schemas)
- Record transaction status events and post ledger entries on successful payment verification
- Capture Paystack verify fees and propagate amount/fee through payment types

## Test plan
- [ ] Hit `GET /api/wallets/:walletId/ledger` with paging/date filters
- [ ] Verify payment flow still confirms order and emits outbox event
- [ ] Confirm ledger entries created with gateway fee applied

Made with [Cursor](https://cursor.com)