### PR TITLE
Fix: P1 reconciliation issues and repair security

### DIFF
--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -5,6 +5,7 @@ import { LedgerEntry, Wallet, type ILedgerEntry } from "../models/index.js";
 import { NotFoundError, ValidationError } from "../utils/AppError.js";
 import { WalletService } from "../services/WalletService.js";
 import { ReconciliationService } from "../services/ReconciliationService.js";
+import { AuditService } from "../services/AuditService.js";
 import type { z } from "zod";
 import type {
   walletLedgerParamsSchema,
@@ -35,19 +36,47 @@ export class WalletController {
 
   static repair = asyncHandler(async (req: Request, res: Response) => {
     const { walletId } = req.params as z.infer<typeof walletLedgerParamsSchema>;
-    const { dryRun } = (req.body ?? {}) as z.infer<typeof repairBodySchema>;
+    const { dryRun, confirm } = (req.body ?? {}) as z.infer<
+      typeof repairBodySchema
+    >;
+
+    /* Non-dry-run repairs require explicit confirmation */
+    if (!dryRun && !confirm) {
+      throw ValidationError(
+        "Destructive operation: set { confirm: true } to proceed, or use { dryRun: true } to preview."
+      );
+    }
 
     const userId = req.user?.userId;
     const isValidObjectId =
       typeof userId === "string" && /^[0-9a-fA-F]{24}$/.test(userId);
 
+    const actor = isValidObjectId
+      ? { type: "ADMIN" as const, id: new mongoose.Types.ObjectId(userId) }
+      : { type: "SYSTEM" as const };
+    const source = isValidObjectId
+      ? "reconciliation:admin"
+      : "reconciliation:auto";
+
     const report = await ReconciliationService.repairUnposted({
       walletId,
-      actor: isValidObjectId
-        ? { type: "ADMIN", id: new mongoose.Types.ObjectId(userId) }
-        : { type: "SYSTEM" },
-      source: isValidObjectId ? "reconciliation:admin" : "reconciliation:auto",
+      actor,
+      source,
       dryRun,
+    });
+
+    /* Audit log */
+    await AuditService.log({
+      action: "RECONCILIATION_REPAIR",
+      actor: AuditService.getActorFromRequest(req),
+      entity: { type: "Other", id: walletId, name: "Wallet" },
+      request: AuditService.getRequestContext(req),
+      result: { success: true },
+      metadata: {
+        dryRun,
+        ...report.summary,
+      },
+      severity: dryRun ? "info" : "warning",
     });
 
     res.status(200).json({

--- a/src/schemas/walletSchemas.ts
+++ b/src/schemas/walletSchemas.ts
@@ -17,4 +17,5 @@ export const walletLedgerQuerySchema = z.object({
 
 export const repairBodySchema = z.object({
   dryRun: z.boolean().optional().default(false),
+  confirm: z.boolean().optional().default(false),
 });

--- a/src/services/ReconciliationService.ts
+++ b/src/services/ReconciliationService.ts
@@ -20,7 +20,13 @@ export type ReconciliationReport = {
   drift: { available: number; pending: number };
   isBalanced: boolean;
   unpostedTransactions: number;
-  entries: { total: number; debits: number; credits: number };
+  entries: {
+    total: number;
+    debitCount: number;
+    creditCount: number;
+    debitSum: number;
+    creditSum: number;
+  };
 };
 
 export type RepairResult = {
@@ -75,6 +81,8 @@ export class ReconciliationService {
     let ledgerPending = 0;
     let totalDebits = 0;
     let totalCredits = 0;
+    let debitSum = 0;
+    let creditSum = 0;
     let totalEntries = 0;
 
     for (const row of agg) {
@@ -82,8 +90,13 @@ export class ReconciliationService {
       if (row._id.bucket === "AVAILABLE") ledgerAvailable += signed;
       else ledgerPending += signed;
 
-      if (row._id.direction === "DEBIT") totalDebits += row.count;
-      else totalCredits += row.count;
+      if (row._id.direction === "DEBIT") {
+        totalDebits += row.count;
+        debitSum += row.total;
+      } else {
+        totalCredits += row.count;
+        creditSum += row.total;
+      }
       totalEntries += row.count;
     }
 
@@ -111,8 +124,10 @@ export class ReconciliationService {
       unpostedTransactions: unposted,
       entries: {
         total: totalEntries,
-        debits: totalDebits,
-        credits: totalCredits,
+        debitCount: totalDebits,
+        creditCount: totalCredits,
+        debitSum,
+        creditSum,
       },
     };
   }
@@ -181,7 +196,6 @@ export class ReconciliationService {
       const session = await mongoose.startSession();
       session.startTransaction();
       try {
-        /* Re-check inside session: another process may have posted it */
         const freshTx = await Transaction.findById(tx._id).session(session);
         if (!freshTx || freshTx.postedAt) {
           await session.abortTransaction();

--- a/src/services/WalletService.ts
+++ b/src/services/WalletService.ts
@@ -1,17 +1,9 @@
 import mongoose from "mongoose";
-import { Wallet, type IWallet } from "../models/index.js";
+import { Wallet, LedgerEntry, type IWallet } from "../models/index.js";
 
 const STORE_OWNER_ID = new mongoose.Types.ObjectId("000000000000000000000001");
 
 export class WalletService {
-  /**
-   * Returns the well-known store wallet for the given currency,
-   * creating it on first access.
-   *
-   * When called with a session the lookup + create runs inside that
-   * transaction (used by LedgerService). Without a session it runs
-   * as a normal query (used by the bootstrap endpoint).
-   */
   static async getStoreWallet(
     currency = "NGN",
     session?: mongoose.ClientSession
@@ -43,7 +35,7 @@ export class WalletService {
     return created;
   }
 
-  /** Lightweight summary: wallet balances + metadata. */
+  /** Lightweight summary: wallet balances + last posting date for this wallet. */
   static async getWalletSummary(walletId: string): Promise<{
     wallet: IWallet;
     lastPostedAt: Date | null;
@@ -51,15 +43,14 @@ export class WalletService {
     const wallet = await Wallet.findById(walletId).lean<IWallet>();
     if (!wallet) throw new Error("Wallet not found.");
 
-    const { Transaction } = await import("../models/index.js");
-    const lastPosted = await Transaction.findOne({ postedAt: { $ne: null } })
-      .sort({ postedAt: -1 })
-      .select("postedAt")
+    const lastEntry = await LedgerEntry.findOne({ walletId: wallet._id })
+      .sort({ createdAt: -1 })
+      .select("createdAt")
       .lean();
 
     return {
       wallet,
-      lastPostedAt: lastPosted?.postedAt ?? null,
+      lastPostedAt: lastEntry?.createdAt ?? null,
     };
   }
 }


### PR DESCRIPTION
Fixes P1 data-integrity issues and adds safety mechanisms to the reconciliation service.

## Issues Fixed
- **#25** — \econcileWallet\ returned counts of entries under \debits/credits\. Renamed to \debitCount\/\creditCount\ and added \debitSum\/\creditSum\ for total amounts.
- **#26** — \getWalletSummary\ \lastPostedAt\ field mistakenly returned latest activity globally. Scoped to the specific wallet using \LedgerEntry\.
- **#24** — Repair endpoint is destructive and could accidentally run. Added a \confirm\ boolean requirement and comprehensive \AuditService\ logs capturing the trigger, request context, and the summary.

Closes #24, Closes #25, Closes #26