### PR TITLE
feat: Implement admin user list endpoint with pagination and filtering

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -19,6 +19,7 @@ import type {
   resetPasswordSchema,
   reasonSchema,
   updateProfileSchema,
+  adminUsersQuerySchema,
 } from "../schemas/userSchemas.js";
 
 const IS_PROD = process.env.NODE_ENV === "production";
@@ -331,6 +332,19 @@ export class UserController {
       success: true,
       message: "Profile updated.",
       data: user,
+    });
+  });
+
+  static getUsersAdmin = asyncHandler(async (req: Request, res: Response) => {
+    const filters = req.query as unknown as z.infer<
+      typeof adminUsersQuerySchema
+    >;
+
+    const result = await UserService.getUsersAdmin(filters);
+
+    res.status(200).json({
+      success: true,
+      data: result,
     });
   });
 }

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -21,7 +21,15 @@ export function validate(schema: ZodSchema, target: ValidationTarget = "body") {
       return;
     }
 
-    req[target] = result.data;
+    if (target === "body") {
+      req.body = result.data;
+    } else {
+      const source = req[target];
+      for (const key of Object.keys(source)) {
+        delete (source as Record<string, unknown>)[key];
+      }
+      Object.assign(source, result.data);
+    }
     next();
   };
 }

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -18,6 +18,7 @@ import {
   resetPasswordSchema,
   reasonSchema,
   updateProfileSchema,
+  adminUsersQuerySchema,
 } from "../schemas/userSchemas.js";
 
 const router = Router();
@@ -61,6 +62,16 @@ router.patch(
 );
 
 router.get("/me", authMiddleware, UserController.getMe);
+
+const adminOnly = [authMiddleware, requireRole("ADMIN")] as const;
+
+router.get(
+  "/admin",
+  ...adminOnly,
+  validate(adminUsersQuerySchema, "query"),
+  UserController.getUsersAdmin
+);
+
 router.get(
   "/:userId",
   authMiddleware,
@@ -79,8 +90,6 @@ router.patch(
   validate(updateProfileSchema),
   UserController.updateProfile
 );
-
-const adminOnly = [authMiddleware, requireRole("ADMIN")] as const;
 
 router.patch(
   "/:userId/suspend",

--- a/src/schemas/userSchemas.ts
+++ b/src/schemas/userSchemas.ts
@@ -45,3 +45,13 @@ export const updateProfileSchema = z
   .refine((data) => data.name !== undefined || data.address !== undefined, {
     message: "Provide at least one field to update (name or address).",
   });
+
+export const adminUsersQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  search: z.string().optional(),
+  role: z.enum(["USER", "ADMIN"]).optional(),
+  status: z
+    .enum(["UNVERIFIED", "ACTIVE", "SUSPENDED", "DEACTIVATED", "PENDING"])
+    .optional(),
+});

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -671,4 +671,46 @@ export class UserService {
       session.endSession();
     }
   }
+
+  static async getUsersAdmin(filters: {
+    page: number;
+    limit: number;
+    search?: string;
+    role?: string;
+    status?: string;
+  }): Promise<{ users: IUser[]; total: number; totalPages: number }> {
+    const { page, limit, search, role, status } = filters;
+    const query: Record<string, any> = {};
+
+    if (search) {
+      query.$or = [
+        { name: { $regex: search, $options: "i" } },
+        { email: { $regex: search, $options: "i" } },
+      ];
+    }
+    if (role) {
+      query.role = role;
+    }
+    if (status) {
+      query.status = status;
+    }
+
+    const skip = (page - 1) * limit;
+
+    const [users, total] = await Promise.all([
+      User.find(query)
+        .select("-password")
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean<IUser[]>(),
+      User.countDocuments(query),
+    ]);
+
+    return {
+      users,
+      total,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
 }


### PR DESCRIPTION
Resolves #36. Adds admin endpoints to fetch users supporting search, role, and status filtering.