### PR TITLE
fix: Correct role and status enums in admin users query schema

### DIFF
--- a/src/schemas/userSchemas.ts
+++ b/src/schemas/userSchemas.ts
@@ -50,8 +50,8 @@ export const adminUsersQuerySchema = z.object({
   page: z.coerce.number().int().min(1).optional().default(1),
   limit: z.coerce.number().int().min(1).max(100).optional().default(20),
   search: z.string().optional(),
-  role: z.enum(["USER", "ADMIN"]).optional(),
+  role: z.enum(["CUSTOMER", "SUPPORT", "ADMIN"]).optional(),
   status: z
-    .enum(["UNVERIFIED", "ACTIVE", "SUSPENDED", "DEACTIVATED", "PENDING"])
+    .enum(["UNVERIFIED", "ACTIVE", "SUSPENDED", "DEACTIVATED"])
     .optional(),
 });


### PR DESCRIPTION
Fixes adminUsersQuerySchema to use correct backend enums. Roles: CUSTOMER/SUPPORT/ADMIN. Statuses: UNVERIFIED/ACTIVE/SUSPENDED/DEACTIVATED (removed invalid PENDING).