### PR TITLE
fix: filter admin orders by userId for user detail page

### DIFF
--- a/src/controllers/OrderController.ts
+++ b/src/controllers/OrderController.ts
@@ -91,11 +91,16 @@ export class OrderController {
   /* ── Admin: list ALL orders (paginated + filterable) ── */
 
   static getAllOrders = asyncHandler(async (req: Request, res: Response) => {
-    const { page, limit, status, search } = req.query as unknown as z.infer<
-      typeof adminOrderQuerySchema
-    >;
+    const { page, limit, status, search, userId } =
+      req.query as unknown as z.infer<typeof adminOrderQuerySchema>;
 
-    const result = await OrderService.getAllOrders(page, limit, status, search);
+    const result = await OrderService.getAllOrders(
+      page,
+      limit,
+      status,
+      search,
+      userId
+    );
     res.status(200).json({ success: true, data: result });
   });
 

--- a/src/schemas/orderSchemas.ts
+++ b/src/schemas/orderSchemas.ts
@@ -89,6 +89,7 @@ export const adminOrderQuerySchema = z.object({
     ])
     .optional(),
   search: z.string().max(200).optional(),
+  userId: z.string().min(1).optional(),
 });
 
 export const guestOrderQuerySchema = z.object({

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -392,7 +392,8 @@ export class OrderService {
     page = 1,
     limit = 20,
     status?: OrderStatus,
-    search?: string
+    search?: string,
+    userId?: string
   ): Promise<{
     orders: IOrder[];
     total: number;
@@ -404,6 +405,7 @@ export class OrderService {
 
     const filter: Record<string, unknown> = {};
     if (status) filter.status = status;
+    if (userId) filter.user = userId;
     if (search) {
       const escaped = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       filter.$or = [
@@ -986,7 +988,6 @@ export class OrderService {
     const event = (await TrackingEvent.create(
       eventData
     )) as unknown as ITrackingEvent;
-
 
     if (order.status !== status) {
       assertValidTransition(order.status, status);


### PR DESCRIPTION
The admin UserDetailPage sends userId when fetching recent orders, but the backend was silently stripping it. Added userId to schema, controller, and service filter.