### PR TITLE
feat: product sales stats endpoint (GET /products/stats)

### DIFF
--- a/src/controllers/ProductController.ts
+++ b/src/controllers/ProductController.ts
@@ -128,4 +128,10 @@ export class ProductController {
     const brands = await ProductService.getBrands();
     res.status(200).json({ success: true, data: brands });
   });
+
+  static getSalesStats = asyncHandler(async (req: Request, res: Response) => {
+    const productId = req.query.productId as string | undefined;
+    const stats = await ProductService.getProductSalesStats(productId);
+    res.status(200).json({ success: true, data: stats });
+  });
 }

--- a/src/routes/productRoutes.ts
+++ b/src/routes/productRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { ProductController } from "../controllers/ProductController.js";
 import { authMiddleware } from "../middleware/authMiddleware.js";
+import { requireRole } from "../middleware/requireRole.js";
 import { validate } from "../middleware/validate.js";
 import {
   createProductSchema,
@@ -11,6 +12,12 @@ const router = Router();
 
 router.get("/categories", ProductController.getCategories);
 router.get("/brands", ProductController.getBrands);
+router.get(
+  "/stats",
+  authMiddleware,
+  requireRole("ADMIN"),
+  ProductController.getSalesStats
+);
 router.get("/sku/:sku", ProductController.getProductBySku);
 router.get("/slug/:slug", ProductController.getProductBySlug);
 router.get("/", ProductController.getProducts);

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -419,6 +419,53 @@ export class ProductService {
     };
   }
 
+  static async getProductSalesStats(productId?: string): Promise<{
+    totalUnitsSold: number;
+    totalRevenue: number;
+    orderCount: number;
+  }> {
+    const { Order } = await import("../models/index.js");
+
+    const pipeline: mongoose.PipelineStage[] = [
+      {
+        $match: {
+          status: { $in: ["CONFIRMED", "SHIPPED", "DELIVERED"] },
+        },
+      },
+      { $unwind: "$items" as const },
+    ];
+
+    if (productId) {
+      pipeline.push({
+        $match: {
+          "items.product": new mongoose.Types.ObjectId(productId),
+        },
+      });
+    }
+
+    pipeline.push(
+      {
+        $group: {
+          _id: null,
+          totalUnitsSold: { $sum: "$items.quantity" },
+          totalRevenue: { $sum: "$items.subtotal" },
+          orderIds: { $addToSet: "$_id" },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          totalUnitsSold: 1,
+          totalRevenue: 1,
+          orderCount: { $size: "$orderIds" },
+        },
+      }
+    );
+
+    const result = await Order.aggregate(pipeline);
+    return result[0] ?? { totalUnitsSold: 0, totalRevenue: 0, orderCount: 0 };
+  }
+
   static async getCategories(): Promise<string[]> {
     return Product.distinct("category", { isActive: true });
   }


### PR DESCRIPTION
Adds a MongoDB aggregation endpoint returning totalUnitsSold, totalRevenue, and orderCount. Accepts optional productId query param - filters to one product when provided, aggregates all products when omitted.