### PR TITLE
Fix inventory release logic on order cancellation

### DIFF
--- a/src/models/StockMovement.ts
+++ b/src/models/StockMovement.ts
@@ -6,6 +6,7 @@ export type StockMovementType =
   | "RESERVE"
   | "RELEASE"
   | "COMMIT"
+  | "CANCELLATION_REVERSAL"
   | "ADJUSTMENT";
 
 export interface IStockMovementReference {
@@ -55,6 +56,7 @@ const stockMovementSchema = new Schema<IStockMovement>(
         "RESERVE",
         "RELEASE",
         "COMMIT",
+        "CANCELLATION_REVERSAL",
         "ADJUSTMENT",
       ],
       required: true,

--- a/src/services/InventoryService.ts
+++ b/src/services/InventoryService.ts
@@ -355,4 +355,57 @@ export class InventoryService {
       }
     }
   }
+
+  static async restoreCommittedStock(
+    productId: string,
+    quantity: number,
+    session?: ClientSession | null,
+    performedBy?: string
+  ): Promise<IInventory> {
+    if (quantity <= 0)
+      throw ValidationError("Quantity must be greater than zero.");
+
+    await InventoryService.ensureActiveProduct(productId, session);
+
+    const ownSession = !session;
+    const sess = session ?? (await mongoose.startSession());
+    if (ownSession) {
+      sess.startTransaction();
+    }
+
+    try {
+      const inventory = await Inventory.findOne({ product: productId }).session(
+        sess
+      );
+      if (!inventory) throw NotFoundError("Inventory");
+
+      inventory.stock += quantity;
+      await inventory.save({ session: sess });
+
+      await InventoryService.recordMovement(
+        inventory,
+        "CANCELLATION_REVERSAL",
+        quantity,
+        1,
+        sess,
+        { reason: "Order cancelled – committed stock restored" },
+        performedBy
+      );
+
+      if (ownSession) {
+        await sess.commitTransaction();
+      }
+
+      return inventory.toObject() as IInventory;
+    } catch (error) {
+      if (ownSession) {
+        await sess.abortTransaction();
+      }
+      throw error;
+    } finally {
+      if (ownSession) {
+        sess.endSession();
+      }
+    }
+  }
 }

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -546,14 +546,24 @@ export class OrderService {
       const order = await Order.findById(orderId).session(session);
       if (!order) throw NotFoundError("Order");
 
+      const previousStatus = order.status;
+
       assertValidTransition(order.status, "CANCELLED");
 
       for (const item of order.items) {
-        await InventoryService.releaseReservation(
-          item.product.toString(),
-          item.quantity,
-          session
-        );
+        if (previousStatus === "PENDING") {
+          await InventoryService.releaseReservation(
+            item.product.toString(),
+            item.quantity,
+            session
+          );
+        } else {
+          await InventoryService.restoreCommittedStock(
+            item.product.toString(),
+            item.quantity,
+            session
+          );
+        }
       }
 
       order.status = "CANCELLED";


### PR DESCRIPTION
Resolves https://github.com/varletint/atomic-vault/issues/43

Adds restoreCommittedStock to handle inventory restoration when cancelling already confirmed or shipped orders.